### PR TITLE
Migrate sql client

### DIFF
--- a/src/SqlAlias/SqlAlias.cs
+++ b/src/SqlAlias/SqlAlias.cs
@@ -1,7 +1,7 @@
 using System;
 #if !NET40
+using Microsoft.Data.SqlClient;
 using System.Runtime.InteropServices;
-using System.Data.SqlClient;
 #endif
 
 namespace SqlAlias

--- a/src/SqlAlias/SqlAlias.csproj
+++ b/src/SqlAlias/SqlAlias.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <AssemblyName>SqlAlias</AssemblyName>
     <RootNamespace>SqlAlias</RootNamespace>
     <PackageId>SqlAlias</PackageId>
@@ -14,13 +14,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-  </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />

--- a/src/SqlAlias/SqlAlias.csproj
+++ b/src/SqlAlias/SqlAlias.csproj
@@ -14,10 +14,9 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
-  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Use `Microsoft.Data.SqlClient` instead of `System.Data.SqlClient` as Microsoft is actively developing `Microsoft.Data.SqlClient`. There are new connection string features in `Microsoft.Data.SqlClient`.