### PR TITLE
Use appropriate registry keys for x64/x86 systems

### DIFF
--- a/src/SqlAlias/SqlAlias.cs
+++ b/src/SqlAlias/SqlAlias.cs
@@ -4,7 +4,20 @@ using Microsoft.Data.SqlClient;
 using System.Runtime.InteropServices;
 
 #endif
+#if false
+    if(OperatingSystem.IsWindows() && strConString.Contains("source=syn")) {
+				var builder = new SqlConnectionStringBuilder(strConString);
 
+				var key = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") != "x86"
+					? @"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\MSSQLServer\Client\ConnectTo"
+					: @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSSQLServer\Client\ConnectTo";
+
+				if(Microsoft.Win32.Registry.GetValue(key, builder.DataSource, null) is string newSource) {
+					builder.DataSource = newSource.Substring(newSource.IndexOf(',') + 1);
+				}
+				strConString = builder.ConnectionString;
+    
+#endif
 namespace SqlAlias
 {
     public static class Aliases

--- a/src/SqlAlias/SqlAlias.cs
+++ b/src/SqlAlias/SqlAlias.cs
@@ -4,20 +4,6 @@ using Microsoft.Data.SqlClient;
 using System.Runtime.InteropServices;
 
 #endif
-#if false
-    if(OperatingSystem.IsWindows() && strConString.Contains("source=syn")) {
-				var builder = new SqlConnectionStringBuilder(strConString);
-
-				var key = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") != "x86"
-					? @"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\MSSQLServer\Client\ConnectTo"
-					: @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSSQLServer\Client\ConnectTo";
-
-				if(Microsoft.Win32.Registry.GetValue(key, builder.DataSource, null) is string newSource) {
-					builder.DataSource = newSource.Substring(newSource.IndexOf(',') + 1);
-				}
-				strConString = builder.ConnectionString;
-    
-#endif
 namespace SqlAlias
 {
     public static class Aliases
@@ -34,11 +20,14 @@ namespace SqlAlias
             try
             {
                 var builder = new SqlConnectionStringBuilder(connectionString);
-
-                var newSource = (string) Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSSQLServer\Client\ConnectTo", builder.DataSource, null);
-                if (newSource != null)
+                //select registry key for 64/32 bit systems
+                var key = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") != "x86"
+                    ? @"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\MSSQLServer\Client\ConnectTo"
+                    : @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSSQLServer\Client\ConnectTo";
+                if(Microsoft.Win32.Registry.GetValue(key, builder.DataSource, null) is string newSource) 
+                {
                     builder.DataSource = newSource.Substring(newSource.IndexOf(',') + 1);
-
+                }
                 return builder.ConnectionString;
             }
             catch (Exception ex)


### PR DESCRIPTION
On x64 systems HKLM...\WOW6432... holds the alias values. So the code has to decide if this key or (on x86) the original one should be used.