### PR TITLE
Patch SqlClient vulnerability

### DIFF
--- a/src/SqlAlias/SqlAlias.csproj
+++ b/src/SqlAlias/SqlAlias.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net40' ">
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
   


### PR DESCRIPTION
Microsoft disclosed a [moderate vulnerability](https://github.com/advisories/GHSA-8g2p-5pqh-5jmc) on their SqlClient libraries affecting a few versions.

This PR updates such library to a patched version.

https://octopusdeploy.slack.com/archives/C04AD1H7LLC/p1668387022805969

[sc-30875]